### PR TITLE
custom slave response_timeout

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-flasher (1.0.6) stable; urgency=medium
+
+  * Added custom response timeout option (-t)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Sun, 3 May 2020 20:40:10 +0300
+
 wb-mcu-fw-flasher (1.0.5) stable; urgency=medium
 
   * factory first time fast flashing support. baudrate select option -B


### PR DESCRIPTION
Response timeout теперь можно задавать через аргумент. (если не получен ответ от устройства в течение этого времени, кидается ошибка connection_timeout).

Зачем: хочу в апдейтере прошивок сделать ручку "всё сломалось, устройство в бутлоадере, slaveid не помню". Апдейтер будет ходить по всем slaveid и пытаться запустить flasher с маленьким response timeout (чтобы не ждать 10 секунд каждый раз).

проверил на WB и ноуте