### PR TITLE
Add arm64 and amd64 build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildDebSbuild(
-    defaultTargets: 'wb5 wb6 bullseye-arm64 bullseye-host',
+    defaultTargets: 'bullseye-armhf bullseye-arm64 bullseye-host',
     repos: ['release', 'devTools'],
     defaultRunLintian: true,
     customBuildSteps: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 buildDebSbuild(
     defaultTargets: 'wb5 wb6 bullseye-arm64 bullseye-host',
     repos: ['release', 'devTools'],
+    defaultRunLintian: true,
     customBuildSteps: {
         stage("Build win32") {
             dir("$PROJECT_SUBDIR") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,10 @@
 buildDebSbuild(
-    defaultTargets: 'wb5 wb6',
+    defaultTargets: 'wb5 wb6 bullseye-arm64 bullseye-host',
+    repos: ['release', 'devTools'],
     customBuildSteps: {
         stage("Build win32") {
             dir("$PROJECT_SUBDIR") {
-                sh 'wbdev root bash -c "apt-get update && apt-get -y install gcc-mingw-w64-i686 && unset CC &&  make win32"'
+                sh 'wbdev root bash -c "apt-get update && apt-get -y install gcc-mingw-w64-i686 && unset CC && make win32"'
             }
             sh "mv $PROJECT_SUBDIR/*.exe $RESULT_SUBDIR/"
             archiveArtifacts artifacts: "$RESULT_SUBDIR/*.exe"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-flasher (1.3.1) stable; urgency=medium
+
+  * Add arm64 and amd64 build, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 15 Nov 2023 13:01:00 +0400
+
 wb-mcu-fw-flasher (1.3.0) stable; urgency=medium
 
   * Add -J flag: jump to bootloader with current baudrate


### PR DESCRIPTION
Сейчас на вики https://wirenboard.com/wiki/Wb-mcu-fw-flasher#%D0%9E%D0%A1_Linux предлагается скачать прикрепленную дебку под amd64, к тому же старую 1.0.3. Теперь будет доступно через dev-tools репу.