### PR TITLE
Feature/print fwsig

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-wb-mcu-fw-flasher (1.3.3) stable; urgency=medium
+wb-mcu-fw-flasher (1.4.0) stable; urgency=medium
 
   * Add --get-device-info arg
 
- -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 04 Apr 2024 19:22:21 +0300
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Fri, 19 Apr 2024 17:19:45 +0300
 
 wb-mcu-fw-flasher (1.3.2) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-flasher (1.3.3) stable; urgency=medium
+
+  * Add --get-fw-sig arg
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 04 Apr 2024 19:22:21 +0300
+
 wb-mcu-fw-flasher (1.3.2) stable; urgency=medium
 
   * Add homepage to deb package info. No functional changes

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mcu-fw-flasher (1.3.3) stable; urgency=medium
 
-  * Add --get-fw-sig arg
+  * Add --get-device-info arg
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 04 Apr 2024 19:22:21 +0300
 

--- a/flasher.c
+++ b/flasher.c
@@ -132,10 +132,14 @@ int main(int argc, char *argv[])
     int   inBootloader = 0;
     float responseTimeout = 10.0f; // Seconds
 
+    const struct option long_options[] = {
+		{ "get-fw-sig", no_argument, &onlyPrintFwSig, 1 },
+		{ NULL, 0, NULL, 0}
+	};
 
     int c;
     int stopbits;
-    while ((c = getopt(argc, argv, "d:f:a:t:jJLuewDb:p:s:B:")) != -1) {
+    while ((c = getopt_long(argc, argv, "d:f:a:t:jJuewDb:p:s:B:", long_options, NULL)) != -1) {
         switch (c) {
         case 'd':
             device = optarg;
@@ -159,9 +163,6 @@ int main(int argc, char *argv[])
             break;
         case 'J':
             jumpCmdCurrentBaud = 1;
-            break;
-        case 'L':
-            onlyPrintFwSig = 1;
             break;
         case 'u':
             uartResetCmd = 1;
@@ -216,7 +217,7 @@ int main(int argc, char *argv[])
                 printf ("Stopbits (-s <%d>) are not supported!\n", stopbits);
                 exit(EXIT_FAILURE);
             };
-        default:
+        case '?':
             printf("Parameters error.\n");
             break;
         }

--- a/flasher.c
+++ b/flasher.c
@@ -569,43 +569,34 @@ int probeConnection(modbus_t *ctx){
 }
 
 int printDeviceInfo(modbus_t *ctx){
-    FILE *stream;
-    ssize_t len;
-    char *buf;
     int rc = 0;
-
-    stream = open_memstream(&buf, &len);
 
     // Read bl-version
     char blVer[8];
     if (readString(ctx, blVer, 330, 8) >= 0){
-        fprintf(stream, "Bootloader version: %s\n", blVer);
+        printf("Bootloader version: %s\n", blVer);
     } else {
-        fprintf(stream, "Bootloader version read error: %s\n", modbus_strerror(errno));
+        printf("Bootloader version read error: %s\n", modbus_strerror(errno));
         rc = errno;
     }
 
     // Read fw-version
     char fwVer[15];
     if (readString(ctx, fwVer, 250, 15) >= 0){
-        fprintf(stream, "Firmware version: %s\n", fwVer);
+        printf("Firmware version: %s\n", fwVer);
     } else {
-        fprintf(stream, "Firmware version read error: %s; Maybe device is in bootloader?\n", modbus_strerror(errno));
+        printf("Firmware version read error: %s; Maybe device is in bootloader?\n", modbus_strerror(errno));
         // do not set rc: bootloader cannot read fw-version
     }
 
     // Read fw-sig
     char fwSig[12];
     if (readString(ctx, fwSig, 290, 12) >= 0){
-        fprintf(stream, "Firmware signature (fw-sig): %s\nDownload firmwares: https://fw-releases.wirenboard.com/?prefix=fw/by-signature/%s/\n", fwSig, fwSig);
+        printf("Firmware signature (fw-sig): %s\nDownload firmwares: https://fw-releases.wirenboard.com/?prefix=fw/by-signature/%s/\n", fwSig, fwSig);
     } else {
-        fprintf(stream, "Firmware signature (fw-sig) read error: %s\n", modbus_strerror(errno));
+        printf("Firmware signature (fw-sig) read error: %s\n", modbus_strerror(errno));
         rc = errno;
     }
-
-    fclose(stream);
-    printf("%s", buf);
-    free(buf);
     return rc;
 }
 

--- a/flasher.c
+++ b/flasher.c
@@ -567,7 +567,7 @@ char *mbReadString(modbus_t *ctx, int startAddr, int len){
         for (int i=0; i < rc; i++) {
             buf[i] = (char)vals[i];
         }
-        buf[len] = "\0";
+        buf[rc] = '\0';
         return buf;
     }
     return NULL;


### PR DESCRIPTION
Пользователи виндавса страдают при необходимости узнать fw-sig => сделали ключик --get-fw-sig

Основной затык - ux вокруг всяких переходов в бутлоадер c/без сохранения настроечек (+ неизвестное состояние при запуске)

вроде получилось все обойти:
![image](https://github.com/wirenboard/wb-mcu-fw-flasher/assets/25829054/01c35ead-f253-4bb1-978a-4cbf2fd1ed71)


на виндавсе еще не тыкал