### PR TITLE
Feature/add jump value

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-flasher (1.6.0) stable; urgency=medium
+
+  * Add --jump-value option to specify custom value for jump to bootloader commands
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Thu, 17 Jul 2025 14:26:58 +0300
+
 wb-mcu-fw-flasher (1.5.0) stable; urgency=medium
 
   * Add full FlashFS erase support for new 1.5.x bootloaders

--- a/flasher.c
+++ b/flasher.c
@@ -319,15 +319,25 @@ int main(int argc, char *argv[])
         }
         sleep(2);    // wait 2 seconds
     } else if (jumpCmdCurrentBaud) {
-        printf("Try to jump to bootloader using current baudrate...\n");
+        if (jumpValue == 1) {
+            printf("Try to jump to bootloader using current baudrate...\n");
+        } else {
+            printf("Try to enter additional firmwares update mode...\n");
+        }
         if (modbus_write_register(deviceParamsConnection, HOLD_REG_JUMP_TO_BOOT_CURRENT_BAUD, jumpValue) == 1) {
             printf("Ok, device supports this. Baudrate %d will be used for flashing.\n", deviceParams.baudrate);
             inBootloader = 1;
         } else {
             fprintf(stderr, "Error while writing register %d: %s.\n", HOLD_REG_JUMP_TO_BOOT_CURRENT_BAUD, modbus_strerror(errno));
             if (errno == EMBXILADD) {
-                fprintf(stderr, "Firmware and/or bootloader doesn't support this command. Please upgrade firmware and/or bootloader.\n");
-                fprintf(stderr, "Alternatively, you can use -j option to jump to bootloader using standard baudrate.\n");
+                if (jumpValue == 1) {
+                    fprintf(stderr, "Firmware and/or bootloader doesn't support this command. Please upgrade firmware and/or bootloader.\n");
+                    fprintf(stderr, "Alternatively, you can use -j option to jump to bootloader using standard baudrate.\n");
+                } else {
+                    fprintf(stderr, "Seems you trying to update addtional device firmwares, but device doesn't support this jump_value.\n");
+                    fprintf(stderr, "Check that your device has installed the sensor with firmware you want to update.\n");
+                    fprintf(stderr, "Also check documentation for supported jump values.\n");
+                }
             } else {
                 fprintf(stderr, "Other error, check device connection parameters.\n");
             }

--- a/flasher.c
+++ b/flasher.c
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
 
     const struct option longOptions[] = {
 		{ "get-device-info", no_argument, &onlyReadInfo, 1 },
-		{ "jump-value", optional_argument, NULL, 0 },
+		{ "jump-value", required_argument, NULL, 0 },
 		{ NULL, 0, NULL, 0}
 	};
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил аргумент `--jump-value`, чтобы можно было переопределять значение, которое записывается в регистра перехода в загрузчик. Нужно для обновления прошивки CO2 датчика. Если записано другое значение, то прошивка понимает, что хотят обновить не прошивку самого устройства, а прошивку датчика. Регистры для блоков данных при этом используются те же.

___________________________________
**Что поменялось для пользователей:**
Теперь можно обновлять прошивки датчиков. Основная прошивка в этом случае выступает шлюзом между датчиков и флешером.

___________________________________
**Как проверял/а:**
На столе на MSW4 + NS8

