### PR TITLE
Add modbus inter-frame delay

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-flasher (1.6.1) stable; urgency=medium
+
+  * Fix modbus interframe delay
+
+ -- Sergey Nikitenko <siarhei.nikitsenka@wirenboard.com>  Tue, 30 Dec 2025 22:00:00 +0300
+
 wb-mcu-fw-flasher (1.6.0) stable; urgency=medium
 
   * Add component firmware information to --get-device-info option

--- a/flasher.c
+++ b/flasher.c
@@ -85,6 +85,8 @@ struct timeval parseResponseTimeout(float timeoutSec);
 
 void setResponseTimeout(struct timeval timeoutStruct, modbus_t *modbusContext);
 
+void interFrameDelay(void);
+
 int main(int argc, char *argv[])
 {
     if (argc == 1) {
@@ -456,6 +458,7 @@ int main(int argc, char *argv[])
         if (modbus_write_registers(bootloaderParamsConnection, INFO_BLOCK_REG_ADDRESS, INFO_BLOCK_SIZE / 2, &data[filePointer / 2]) == (INFO_BLOCK_SIZE / 2)) {
             printf(" OK\n"); fflush(stdout);
             filePointer += INFO_BLOCK_SIZE;
+            interFrameDelay();
             break;
         }
         printf("\n"); fflush(stdout);
@@ -492,6 +495,7 @@ int main(int argc, char *argv[])
         if (modbus_write_registers(bootloaderParamsConnection, DATA_BLOCK_REG_ADDRESS, DATA_BLOCK_SIZE / 2, &data[filePointer / 2]) == (DATA_BLOCK_SIZE / 2)) {
             filePointer += DATA_BLOCK_SIZE;
             errorCount = 0;
+            interFrameDelay();
         } else {
             printf("\n"); fflush(stdout);
             fprintf(stderr, "Error while sending data block: %s\n", modbus_strerror(errno));
@@ -715,4 +719,10 @@ void setResponseTimeout(struct timeval timeoutStruct, modbus_t *modbusContext){
     #else
         modbus_set_response_timeout(modbusContext, &timeoutStruct);
     #endif
+}
+
+void interFrameDelay(void) {
+    // Ensure minimal gap between frames
+    // sleep(0) is sufficient in practice
+    sleep(0);
 }

--- a/flasher.c
+++ b/flasher.c
@@ -722,7 +722,11 @@ void setResponseTimeout(struct timeval timeoutStruct, modbus_t *modbusContext){
 }
 
 void interFrameDelay(void) {
-    // Ensure minimal gap between frames
-    // sleep(0) is sufficient in practice
+    // Workaround for issue FW-1187 (unexpected timeout error).
+    // In rare cases the next frame may start too soon after the previous one,
+    // which can cause a receiving error. Ensuring a minimal gap between frames
+    // resolves the issue. A 100 µs delay is sufficient in practice.
+    // However, we do not have a portable way to implement such a small delay
+    // on all platforms, and sleep(0) has proven to be sufficient.
     sleep(0);
 }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В редких случаях новый блок данных посылается вплотную после подтверждения ответа на предыдущий, что приводит к ошибке приема. Добавили минимальную задержку.

___________________________________
**Что поменялось для пользователей:**

Улучшилась стабильность передачи при обновлении прошивки.

___________________________________
**Как проверял/а:**

осциллографом
